### PR TITLE
Verify image type and allow png, and jpeg images for booking form references.

### DIFF
--- a/src/pages/Booking.tsx
+++ b/src/pages/Booking.tsx
@@ -105,7 +105,6 @@ const Booking = () => {
       });
       console.log(uniqueList);
       setImages(uniqueList);
-      console.log();
     }
   };
 
@@ -119,8 +118,10 @@ const Booking = () => {
     try {
       //get image urls
       const payload = {
-        imageList: images.map(({ id }) => {
-          return id;
+        imageList: images.map(({ id, file }) => {
+          const lowExtension = file.type.toLowerCase();
+          const extension = lowExtension === "jpeg" ? "jpg" : lowExtension;
+          return { id, extension };
         }),
       };
       console.log("payload that is being sent to lambda: " + payload);

--- a/src/pages/Booking.tsx
+++ b/src/pages/Booking.tsx
@@ -81,9 +81,26 @@ const Booking = () => {
   }, []);
 
   const onImageChange = (event: any) => {
+    const validTypes = ["image/jpeg", "image/png"];
     if (event.target.files) {
       console.log(event.target.files);
       const fileList = Array.from(event.target.files as ArrayLike<File>);
+
+      const invalidFiles = fileList.filter(
+        (file) => !validTypes.includes(file.type)
+      );
+      if (invalidFiles.length > 0) {
+        alert("Please upload only valid image formats: JPEG, PNG.");
+        // clear imageInput completely.
+        const imageInput: HTMLInputElement | null = document.getElementById(
+          "reference"
+        ) as HTMLInputElement;
+        if (imageInput) {
+          imageInput.value = "";
+        }
+        return;
+      }
+
       if (fileList.length > 3) {
         console.log(event.target.files);
         alert("Maximum of 3 files are allowed.");
@@ -307,12 +324,14 @@ const Booking = () => {
               )}
             </div>
             <div className="form-control">
-              <label>Include up to 3 image references. *</label>
+              <label htmlFor="reference">
+                Include up to 3 image references (PNG or JPEG files only). *
+              </label>
               <input
                 {...register("reference", { onChange: onImageChange })}
                 id="reference"
                 name="reference"
-                accept="image/*"
+                accept="image/png, image/jpeg"
                 type="file"
                 multiple
               />


### PR DESCRIPTION
Only jpeg and png files are allowed to be uploaded to image references input.

Verifies that inputted images have file types in [jpeg, png].

Standardizes file extension to .jpg or .png.

Sends file extension to lambda function so that url can be created with respective file type.

Uploads images with urls to AWS S3 bucket.

Tested with file extensions: png, PNG, JPG, JPEG, jpg, jpeg.