### PR TITLE
New gallery view for select work, desktop

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -29,6 +29,7 @@ body {
 
 * {
   margin: 0;
+  font-family: Arial, Helvetica, sans-serif;
 }
 
 body {

--- a/src/components/Navbar/Navbar.css
+++ b/src/components/Navbar/Navbar.css
@@ -73,10 +73,6 @@
   right: 1.5rem;
 }
 
-.home-link {
-  display: none;
-}
-
 @media screen and (max-width: 1150px) {
   .nav-menu {
     position: fixed;
@@ -116,15 +112,5 @@
   .nav-list {
     flex-direction: row;
     column-gap: 2.5rem;
-  }
-}
-
-@media (width < 700px) {
-  .nav-logo {
-    display: none;
-  }
-
-  .home-link {
-    display: block;
   }
 }

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -28,7 +28,7 @@ const Navbar = () => {
           id="nav-menu"
         >
           <ul className="nav-list">
-            <li className="nav-item">
+            <li className="nav-item md:hidden">
               <NavLink
                 to="/"
                 className="nav-link home-link"

--- a/src/pages/FlashPage.tsx
+++ b/src/pages/FlashPage.tsx
@@ -23,7 +23,9 @@ const FlashPage = () => {
       columnsDefault={6}
       columnsMobile={2}
     >
-      <h1>Available Flash</h1>
+      <div className="w-full flex flex-row justify-end px-4">
+        <h1 className="font-normal text-gray-500 text-end">available flash</h1>
+      </div>
     </MasonryBase>
   );
 };

--- a/src/pages/FlashPage.tsx
+++ b/src/pages/FlashPage.tsx
@@ -20,7 +20,7 @@ const FlashPage = () => {
           new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
         );
       })}
-      columnsDefault={4}
+      columnsDefault={6}
       columnsMobile={2}
     >
       <h1>Available Flash</h1>

--- a/src/pages/Gallery.css
+++ b/src/pages/Gallery.css
@@ -1,7 +1,7 @@
 .gallery-container {
   /* padding: 30px; */
   margin-top: 100px;
-  padding: 60px 2vw;
+  /* padding: 60px 2vw; */
 }
 
 .gallery-container p {

--- a/src/pages/Gallery.css
+++ b/src/pages/Gallery.css
@@ -1,6 +1,6 @@
 .gallery-container {
   /* padding: 30px; */
-  margin-top: 100px;
+  margin-top: 160px;
   /* padding: 60px 2vw; */
 }
 
@@ -9,8 +9,8 @@
 }
 
 .gallery-container h1 {
-  font-size: 2rem;
-  font-weight: 600;
+  /* font-size: 2rem; */
+  /* font-weight: 600; */
   margin-bottom: 20px;
 }
 

--- a/src/pages/Gallery.css
+++ b/src/pages/Gallery.css
@@ -18,14 +18,14 @@
   position: relative;
   width: 100%;
   display: flex;
-  gap: 10px;
+  gap: 1px;
 }
 
 .column {
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 1px;
 }
 
 .post {

--- a/src/pages/Gallery.css
+++ b/src/pages/Gallery.css
@@ -14,31 +14,6 @@
   margin-bottom: 20px;
 }
 
-.photo-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-  gap: 16px;
-  max-width: 1040px;
-  margin: 0 auto;
-}
-
-.photo-grid .card {
-  background-color: #c9c9c9;
-  width: 100%;
-  object-fit: cover;
-  overflow: hidden;
-  aspect-ratio: 3 / 4;
-  display: flex; /* To center content inside, if needed */
-  align-items: center;
-  justify-content: center;
-}
-
-.photo-grid .card img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-}
-
 .masonry-container {
   position: relative;
   width: 100%;

--- a/src/pages/Gallery.tsx
+++ b/src/pages/Gallery.tsx
@@ -57,6 +57,9 @@ const Gallery = () => {
 
   return (
     <section className="gallery-container">
+      <h1 className="font-normal mr-4 text-gray-500 text-end">
+        select work: 2023-2025
+      </h1>
       {isMobile ? (
         <></>
       ) : (
@@ -116,7 +119,7 @@ const Gallery = () => {
             </div>
           ))
         ) : (
-          <div className="flex flex-col gap-2 items-end md:pl-0 md:grid md:grid-cols-[repeat(auto-fill,_minmax(200px,_1fr))] md:gap-4 md:max-w-[1040px] md:mx-auto">
+          <div className="flex flex-col gap-[1px] items-end md:pl-0 md:grid md:grid-cols-[repeat(auto-fill,_minmax(200px,_1fr))] md:gap-4 md:max-w-[1040px] md:mx-auto">
             {workImages?.map((img, i) => (
               <div
                 className="md:bg-[#c9c9c9] md:w-full md:object-cover md:overflow-hidden md:aspect-[3/4] md:flex md:items-center md:justify-center"

--- a/src/pages/Gallery.tsx
+++ b/src/pages/Gallery.tsx
@@ -44,6 +44,7 @@ const Gallery = () => {
       <div className="w-full flex flex-row justify-start">
         <div className="flex flex-row gap-2">
           <span
+            onClick={() => setShowDefaultView(true)}
             className={`${
               showDefaultView
                 ? "text-gray-600"
@@ -53,55 +54,65 @@ const Gallery = () => {
             [Default]
           </span>
           <span
-            className={`text-gray-800/50 hover:text-gray-800 cursor-pointer`}
+            onClick={() => {
+              setShowDefaultView(false);
+            }}
+            className={`${
+              showDefaultView
+                ? "text-gray-800/50 hover:text-gray-800"
+                : "text-gray-600"
+            } cursor-pointer`}
           >
             [Grid]
           </span>
         </div>
       </div>
       <div>
-        {rows?.map((row, i) => (
-          <div
-            key={i}
-            className="grid grid-cols-12 gap-4"
-            style={{ transform: `translateY(-${i * 20}%)` }}
-          >
-            {row.map((image, index) => {
-              // Randomly assign the image to one of the 6 columns
-              const randomColumn = Math.floor(Math.random() * 6) * 2; // Randomly select 0, 2, 4, 6, 8, 10
-              return (
-                <div
-                  key={index}
-                  className="col-span-2 column min-w-44"
-                  style={{ gridColumnStart: `${randomColumn + 1}` }}
-                >
-                  <img
-                    src={image.src}
-                    alt={image.alt}
-                    className="w-full h-auto object-cover"
-                  />
-                </div>
-              );
-            })}
-          </div>
-        ))}
-        <div className="flex flex-col gap-2 items-end pl-10 md:pl-0 md:grid md:grid-cols-[repeat(auto-fill,_minmax(200px,_1fr))] md:gap-4 md:max-w-[1040px] md:mx-auto">
-          {workImages?.map((img, i) => (
+        {showDefaultView ? (
+          rows?.map((row, i) => (
             <div
-              className="md:bg-[#c9c9c9] md:w-full md:object-cover md:overflow-hidden md:aspect-[3/4] md:flex md:items-center md:justify-center"
               key={i}
+              className="grid grid-cols-12 gap-4"
+              style={{ transform: `translateY(-${i * 20}%)` }}
             >
-              <img
-                className="w-full h-full object-cover"
-                width="400"
-                height="400"
-                alt={img.alt}
-                src={img.src}
-                loading={i > 3 ? "lazy" : "eager"}
-              />
+              {row.map((image, index) => {
+                // Randomly assign the image to one of the 6 columns
+                const randomColumn = Math.floor(Math.random() * 6) * 2; // Randomly select 0, 2, 4, 6, 8, 10
+                return (
+                  <div
+                    key={index}
+                    className="col-span-2 column min-w-44"
+                    style={{ gridColumnStart: `${randomColumn + 1}` }}
+                  >
+                    <img
+                      src={image.src}
+                      alt={image.alt}
+                      className="w-full h-auto object-cover"
+                    />
+                  </div>
+                );
+              })}
             </div>
-          ))}
-        </div>
+          ))
+        ) : (
+          <div className="flex flex-col gap-2 items-end pl-10 md:pl-0 md:grid md:grid-cols-[repeat(auto-fill,_minmax(200px,_1fr))] md:gap-4 md:max-w-[1040px] md:mx-auto">
+            {workImages?.map((img, i) => (
+              <div
+                className="md:bg-[#c9c9c9] md:w-full md:object-cover md:overflow-hidden md:aspect-[3/4] md:flex md:items-center md:justify-center"
+                key={i}
+              >
+                <img
+                  className="w-full h-full object-cover"
+                  width="400"
+                  height="400"
+                  alt={img.alt}
+                  src={img.src}
+                  loading={i > 3 ? "lazy" : "eager"}
+                />
+              </div>
+            ))}
+          </div>
+        )}
       </div>
     </section>
   );

--- a/src/pages/Gallery.tsx
+++ b/src/pages/Gallery.tsx
@@ -1,27 +1,107 @@
 import "./Gallery.css";
 import workImages from "../components/SelectWorkImages.tsx";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import goToTop from "../GoToTop.tsx";
 
+type Image = {
+  src: string;
+  alt: string;
+};
+
+function organizeImagesIntoRows(images: Image[]): Image[][] {
+  const rows: Image[][] = [];
+  let remainingImages = [...images];
+
+  while (remainingImages.length > 0) {
+    // Generate a random number of images for the current row (0-2).
+    const imagesInRow = Math.floor(Math.random() * 3); // Random number between 0 and 2.
+
+    // Pull that many images from the remaining array, but don't exceed the available images.
+    const row = remainingImages.splice(0, imagesInRow);
+
+    // Only add the row if it contains images (to avoid adding empty rows).
+    if (row.length > 0) {
+      rows.push(row);
+    }
+  }
+
+  return rows;
+}
+
 const Gallery = () => {
+  const [rows, setRows] = useState<Image[][]>([]);
+  const [showDefaultView, setShowDefaultView] = useState(true);
+
   useEffect(() => {
     goToTop();
+    const rows = organizeImagesIntoRows(workImages);
+    setRows(rows);
+    console.log(rows);
   }, []);
 
   return (
     <section className="gallery-container">
-      <div className="photo-grid">
-        {workImages?.map((img, i) => (
-          <div className="card" key={i}>
-            <img
-              width="400"
-              height="400"
-              alt={img.alt}
-              src={img.src}
-              loading={i > 3 ? "lazy" : "eager"}
-            />
+      <div className="w-full flex flex-row justify-start">
+        <div className="flex flex-row gap-2">
+          <span
+            className={`${
+              showDefaultView
+                ? "text-gray-600"
+                : "text-gray-800/50 hover:text-gray-800"
+            } cursor-pointer`}
+          >
+            [Default]
+          </span>
+          <span
+            className={`text-gray-800/50 hover:text-gray-800 cursor-pointer`}
+          >
+            [Grid]
+          </span>
+        </div>
+      </div>
+      <div>
+        {rows?.map((row, i) => (
+          <div
+            key={i}
+            className="grid grid-cols-12 gap-4"
+            style={{ transform: `translateY(-${i * 20}%)` }}
+          >
+            {row.map((image, index) => {
+              // Randomly assign the image to one of the 6 columns
+              const randomColumn = Math.floor(Math.random() * 6) * 2; // Randomly select 0, 2, 4, 6, 8, 10
+              return (
+                <div
+                  key={index}
+                  className="col-span-2 column min-w-44"
+                  style={{ gridColumnStart: `${randomColumn + 1}` }}
+                >
+                  <img
+                    src={image.src}
+                    alt={image.alt}
+                    className="w-full h-auto object-cover"
+                  />
+                </div>
+              );
+            })}
           </div>
         ))}
+        <div className="flex flex-col gap-2 items-end pl-10 md:pl-0 md:grid md:grid-cols-[repeat(auto-fill,_minmax(200px,_1fr))] md:gap-4 md:max-w-[1040px] md:mx-auto">
+          {workImages?.map((img, i) => (
+            <div
+              className="md:bg-[#c9c9c9] md:w-full md:object-cover md:overflow-hidden md:aspect-[3/4] md:flex md:items-center md:justify-center"
+              key={i}
+            >
+              <img
+                className="w-full h-full object-cover"
+                width="400"
+                height="400"
+                alt={img.alt}
+                src={img.src}
+                loading={i > 3 ? "lazy" : "eager"}
+              />
+            </div>
+          ))}
+        </div>
       </div>
     </section>
   );

--- a/src/pages/Gallery.tsx
+++ b/src/pages/Gallery.tsx
@@ -57,13 +57,10 @@ const Gallery = () => {
 
   return (
     <section className="gallery-container">
-      <h1 className="font-normal mr-4 text-gray-500 text-end">
-        select work: 2023-2025
-      </h1>
-      {isMobile ? (
-        <></>
-      ) : (
-        <div className="w-full flex flex-row justify-start">
+      <div className="w-full flex flex-row justify-end md:justify-between px-4">
+        {isMobile ? (
+          <></>
+        ) : (
           <div className="flex flex-row gap-2">
             <span
               onClick={() => setShowDefaultView(true)}
@@ -88,8 +85,11 @@ const Gallery = () => {
               [Grid]
             </span>
           </div>
-        </div>
-      )}
+        )}
+        <h1 className="font-normal text-gray-500 text-end">
+          select work: 2023-2025
+        </h1>
+      </div>
 
       <div>
         {showDefaultView && !isMobile ? (
@@ -119,7 +119,7 @@ const Gallery = () => {
             </div>
           ))
         ) : (
-          <div className="flex flex-col gap-[1px] items-end md:pl-0 md:grid md:grid-cols-[repeat(auto-fill,_minmax(200px,_1fr))] md:gap-4 md:max-w-[1040px] md:mx-auto">
+          <div className="flex flex-col gap-[1px] items-end md:pl-0 md:grid md:grid-cols-[repeat(auto-fill,_minmax(200px,_1fr))] md:gap-[1px] md:max-w-[1040px] md:mx-auto">
             {workImages?.map((img, i) => (
               <div
                 className="md:bg-[#c9c9c9] md:w-full md:object-cover md:overflow-hidden md:aspect-[3/4] md:flex md:items-center md:justify-center"

--- a/src/pages/Gallery.tsx
+++ b/src/pages/Gallery.tsx
@@ -30,6 +30,7 @@ function organizeImagesIntoRows(images: Image[]): Image[][] {
 
 const Gallery = () => {
   const [rows, setRows] = useState<Image[][]>([]);
+  const [isMobile, setIsMobile] = useState(true);
   const [showDefaultView, setShowDefaultView] = useState(true);
 
   useEffect(() => {
@@ -37,38 +38,58 @@ const Gallery = () => {
     const rows = organizeImagesIntoRows(workImages);
     setRows(rows);
     console.log(rows);
+    const checkIsMobile = () => {
+      setIsMobile(window.matchMedia("(max-width: 768px)").matches);
+      console.log(isMobile);
+      console.log(showDefaultView);
+    };
+
+    // Check on initial render
+    checkIsMobile();
+
+    // Listen for window resize events
+    window.addEventListener("resize", checkIsMobile);
+
+    return () => {
+      window.removeEventListener("resize", checkIsMobile);
+    };
   }, []);
 
   return (
     <section className="gallery-container">
-      <div className="w-full flex flex-row justify-start">
-        <div className="flex flex-row gap-2">
-          <span
-            onClick={() => setShowDefaultView(true)}
-            className={`${
-              showDefaultView
-                ? "text-gray-600"
-                : "text-gray-800/50 hover:text-gray-800"
-            } cursor-pointer`}
-          >
-            [Default]
-          </span>
-          <span
-            onClick={() => {
-              setShowDefaultView(false);
-            }}
-            className={`${
-              showDefaultView
-                ? "text-gray-800/50 hover:text-gray-800"
-                : "text-gray-600"
-            } cursor-pointer`}
-          >
-            [Grid]
-          </span>
+      {isMobile ? (
+        <></>
+      ) : (
+        <div className="w-full flex flex-row justify-start">
+          <div className="flex flex-row gap-2">
+            <span
+              onClick={() => setShowDefaultView(true)}
+              className={`${
+                showDefaultView
+                  ? "text-gray-600"
+                  : "text-gray-800/50 hover:text-gray-800"
+              } cursor-pointer`}
+            >
+              [Scattered]
+            </span>
+            <span
+              onClick={() => {
+                setShowDefaultView(false);
+              }}
+              className={`${
+                showDefaultView
+                  ? "text-gray-800/50 hover:text-gray-800"
+                  : "text-gray-600"
+              } cursor-pointer`}
+            >
+              [Grid]
+            </span>
+          </div>
         </div>
-      </div>
+      )}
+
       <div>
-        {showDefaultView ? (
+        {showDefaultView && !isMobile ? (
           rows?.map((row, i) => (
             <div
               key={i}
@@ -95,7 +116,7 @@ const Gallery = () => {
             </div>
           ))
         ) : (
-          <div className="flex flex-col gap-2 items-end pl-10 md:pl-0 md:grid md:grid-cols-[repeat(auto-fill,_minmax(200px,_1fr))] md:gap-4 md:max-w-[1040px] md:mx-auto">
+          <div className="flex flex-col gap-2 items-end md:pl-0 md:grid md:grid-cols-[repeat(auto-fill,_minmax(200px,_1fr))] md:gap-4 md:max-w-[1040px] md:mx-auto">
             {workImages?.map((img, i) => (
               <div
                 className="md:bg-[#c9c9c9] md:w-full md:object-cover md:overflow-hidden md:aspect-[3/4] md:flex md:items-center md:justify-center"


### PR DESCRIPTION
Select Work gallery:
mobile-> single column 1px gap
desktop offers both scattered and grid views, which can be toggled between

Flash gallery:
remains the same, but gaps between images are 1px